### PR TITLE
🧹 cleanup: remove unreachable commented code in parse_test_xml.py

### DIFF
--- a/parse_test_xml.py
+++ b/parse_test_xml.py
@@ -111,8 +111,6 @@ def start_parsing(log, testcaseName, fileName):
         return invoked
     except Exception:
         return
-        # print("Fail:",testcaseName,"on",fileName)
-        # print("Skip test:",testcaseName,"on",fileName)
 
 
 def find_test_xml_files(directory):
@@ -188,8 +186,6 @@ def find_row(row):
                                 break
             if found:
                 return True
-                # final_df = pd.concat([final_df, pd.DataFrame([row], columns=final_df.columns)], ignore_index=True)
-                # break
     print(row['Method Name'], row['Internal Test Case'], "not found in")
     return False
 


### PR DESCRIPTION
🎯 **What:** Removed unreachable commented-out code following `return` statements in `parse_test_xml.py`.
💡 **Why:** This improves maintainability and readability by eliminating dead code that cannot be executed.
✅ **Verification:**
- Verified removal of identified lines using `sed`.
- Ran the existing test suite `test_parse_test_xml.py` using a mock script to handle environment constraints (missing `pandas`/`matplotlib`), ensuring no regressions in core logic.
- Performed a syntax check with `py_compile`.
- Ensured no temporary files or binary artifacts (`__pycache__`) were included in the final submission.
✨ **Result:** A cleaner and more maintainable `parse_test_xml.py` file.

---
*PR created automatically by Jules for task [2408251176888490289](https://jules.google.com/task/2408251176888490289) started by @firhard*