### PR TITLE
🔒 Remove hardcoded password and sudo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,25 +24,24 @@ RUN echo "JAVA_HOME is set to: $JAVA_HOME" &&  \
     echo "Javac version:" && javac -version &&  \
     echo "Maven version:" && mvn --version
 
-RUN useradd -ms /bin/bash user &&  \
-    echo 'user:password' | chpasswd &&  \
-    usermod -aG sudo user
-
-USER user
+RUN useradd -ms /bin/bash user
 
 WORKDIR /home/user
+
+COPY requirements.txt requirements.txt
+
+RUN pip3 install -r requirements.txt
 
 COPY --chown=user viscount.sh viscount.sh
 COPY --chown=user test-visibility-checker test-visibility-checker
 COPY --chown=user pom-modify pom-modify
 COPY --chown=user parse_test_xml.py parse_test_xml.py
 COPY --chown=user javaagent-listener javaagent-listener
-COPY --chown=user requirements.txt requirements.txt
 
 # Ensure the script has execute permissions
 RUN chmod +x viscount.sh pom-modify/modify-project.sh
 
-RUN pip3 install -r requirements.txt
+USER user
 
 # Default command to run the script
 # You can override this at runtime using Docker run arguments


### PR DESCRIPTION
🎯 **What:** Removed a hardcoded password for the `user` account and revoked its `sudo` privileges in the `Dockerfile`.

⚠️ **Risk:** Hardcoded passwords in Docker images can be easily extracted by anyone with access to the image, leading to unauthorized access. Combined with `sudo` privileges, this could allow an attacker to gain full control over the container environment.

🛡️ **Solution:** 
- The hardcoded password was removed.
- The `user` was removed from the `sudo` group to adhere to the principle of least privilege.
- The `Dockerfile` was reorganized to perform root-level tasks (like installing dependencies) before switching to the non-privileged `user`.
- Ensured `__pycache__` files are not included in the repository.

---
*PR created automatically by Jules for task [13487922675354070130](https://jules.google.com/task/13487922675354070130) started by @firhard*