### PR TITLE
🧹 Remove commented out old lambda iterations

### DIFF
--- a/test-visibility-checker/src/main/java/org/example/TestVisibilityChecker.java
+++ b/test-visibility-checker/src/main/java/org/example/TestVisibilityChecker.java
@@ -81,8 +81,6 @@ public class TestVisibilityChecker {
         CtModel CUTModel = CUTLauncher.buildModel();
 
         ArrayList<CtType<?>> types = new ArrayList<>();
-//        CUTModel.getElements(new TypeFilter<>(CtClass.class)).forEach(ctClass -> types.add(ctClass));
-//        CUTModel.getElements(new TypeFilter<>(CtInterface.class)).forEach(ctInterface -> types.add(ctInterface));
 
         CUTModel.getElements(new TypeFilter<>(CtClass.class)).forEach(types::add);
         CUTModel.getElements(new TypeFilter<>(CtInterface.class)).forEach(types::add);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed commented out old lambda iteration code in `TestVisibilityChecker.java` (lines 84-85).
💡 **Why:** How this improves maintainability
The old lambda syntax was commented out in favor of the cleaner method reference syntax just below it. Removing it removes dead code clutter.
✅ **Verification:** How you confirmed the change is safe
Ran `mvn clean test` in the `test-visibility-checker` directory. It compiled successfully with no errors, confirming no functionality or syntax was broken.
✨ **Result:** The improvement achieved
A cleaner `TestVisibilityChecker.java` source file without unneeded dead code.

---
*PR created automatically by Jules for task [5799373928078356270](https://jules.google.com/task/5799373928078356270) started by @firhard*