### PR TITLE
🔒 Fix Command Injection vulnerability in TestVisibilityChecker

### DIFF
--- a/test-visibility-checker/src/main/java/org/example/TestVisibilityChecker.java
+++ b/test-visibility-checker/src/main/java/org/example/TestVisibilityChecker.java
@@ -160,15 +160,14 @@ public class TestVisibilityChecker {
     protected static String[] getPathToJunit(String path, MavenLauncher.SOURCE_TYPE testSource) {
         File file = new File(path + testSource + ".cp");
         try {
-            final String cmd;
+            ProcessBuilder pb;
+            String outputFileArg = "-Dmdep.outputFile=" + path + testSource + ".cp";
             if (System.getProperty("os.name").startsWith("Windows")) {
-                cmd = "cmd /C mvn dependency:build-classpath -Dmdep.outputFile=" + path + testSource + ".cp";
-            } else if (System.getProperty("os.name").startsWith("Mac OS X")) {
-                cmd = "mvn dependency:build-classpath -Dmdep.outputFile=" + path + testSource + ".cp";
+                pb = new ProcessBuilder("cmd", "/C", "mvn", "dependency:build-classpath", outputFileArg);
             } else {
-                cmd = "mvn dependency:build-classpath -Dmdep.outputFile=" + path + testSource + ".cp";
+                pb = new ProcessBuilder("mvn", "dependency:build-classpath", outputFileArg);
             }
-            Process p = Runtime.getRuntime().exec(cmd);
+            Process p = pb.start();
             new Thread() {
                 @Override
                 public void run() {


### PR DESCRIPTION
🎯 **What:** Fixed a Command Injection vulnerability in `TestVisibilityChecker.java` line 171.
⚠️ **Risk:** The `Runtime.getRuntime().exec` function was being passed a raw concatenated string containing user-influenced data (`path`, `testSource`). An attacker could inject arbitrary shell commands by crafting a malicious path containing shell metacharacters (e.g. spaces, semicolons, backticks).
🛡️ **Solution:** Replaced `Runtime.getRuntime().exec(String)` with `ProcessBuilder`, passing the command and its arguments as explicitly separated strings. This ensures the operating system interprets the user input purely as arguments rather than executable shell directives, neutralizing the injection risk.

---
*PR created automatically by Jules for task [5000966792192423918](https://jules.google.com/task/5000966792192423918) started by @firhard*